### PR TITLE
Fix: Change module name on clicked extension

### DIFF
--- a/browser/modules/bindEvent.js
+++ b/browser/modules/bindEvent.js
@@ -396,7 +396,7 @@ module.exports = {
                 backboneEvents.get().trigger('off:all');
                 const moduleId = $(this).data('module-id');
                 const moduleTitle = $(this).data('module-title');
-                const e = $('#module-container');
+                const e = $('#mainLayerOffcanvas');
                 e.find('.js-module-title').text('');
                 if (moduleTitle) {
                     e.find('.js-module-title').text(moduleTitle);


### PR DESCRIPTION
Click event was looking at the wrong element